### PR TITLE
Customer can add subscription

### DIFF
--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -1,0 +1,16 @@
+class Api::V0::SubscriptionsController < ApplicationController
+  def create
+    subscription = Subscription.new(subscription_params)
+    if subscription.save!
+      params[:teas].each do |tea_id|
+        TeaSubscription.create!(tea_id: tea_id, subscription_id: subscription.id)
+      end
+      render json: SubscriptionSerializer.new(subscription), status: :created
+    end
+  end
+
+  private
+  def subscription_params
+    params.permit(:title, :price, :frequency, :status, :customer_id)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,12 @@
 class ApplicationController < ActionController::API
-  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+  rescue_from ActiveRecord::RecordNotFound, with: :error_message
+  rescue_from ActiveRecord::RecordInvalid, with: :error_message
 
-  def not_found_error(exception)
-    render json: { errors: [{status: 404, details: exception.message }] }, status: :not_found
+  def error_message(exception)
+    if exception.message.include?("exist")
+      render json: { errors: [{status: 404, details: exception.message }] }, status: :not_found
+    else
+      render json: { errors:[{ status: 400, detail: exception.message }] }, status: :bad_request
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def not_found_error(exception)
+    render json: { errors: [{status: 404, details: exception.message }] }, status: :not_found
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,7 +3,7 @@ class Subscription < ApplicationRecord
   has_many :tea_subscriptions, dependent: :destroy
   has_many :teas, through: :tea_subscriptions
 
-  validates_presence_of :title, :price, :frequency, :status
+  validates_presence_of :title, :price, :frequency, :status, :customer_id
   validates :price, numericality: { greater_than: 0 }
 
   enum status: { active: 0, cancelled: 1 }

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,6 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :title, :price, :status, :frequency
+
+  has_many :teas
+end

--- a/app/serializers/tea_serializer.rb
+++ b/app/serializers/tea_serializer.rb
@@ -1,0 +1,5 @@
+class TeaSerializer
+  include JSONAPI::Serializer
+  attributes :title, :description, :temperature, :brew_time
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,12 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  namespace :api do
+    namespace :v0 do
+      resources :customers, only: [] do
+        resources :subscriptions, only: [:create]
+      end
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,7 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+Customer.create(first_name: "John", last_name: "Doe", email: "email@email.com", address: "123 4th Ave, Indianapolis, IN, 46259")
+Tea.create(title: "Earl Grey", description: "great in the morning", temperature: 195, brew_time: 3.5)
+Tea.create(title: "Green Tea", description: "soothing", temperature: 165, brew_time: 2)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Subscription, type: :model do
   describe "validations" do
     it { should validate_presence_of :title }
     it { should validate_presence_of :frequency }
+    it { should validate_presence_of :customer_id }
   
     it { should validate_presence_of :price }
     it { should validate_numericality_of(:price).is_greater_than(0) }

--- a/spec/requests/api/v0/customer_adds_subscription_spec.rb
+++ b/spec/requests/api/v0/customer_adds_subscription_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
+  let!(:customer) { Customer.create(first_name: "John", last_name: "Doe", email: "email@email.com", address: "123 4th Ave, Indianapolis, IN, 46259") }
+  let!(:tea_1) { Tea.create(title: "Earl Grey", description: "great in the morning", temperature: 195, brew_time: 3.5) }
+  let!(:tea_2) { Tea.create(title: "Green Tea", description: "soothing", temperature: 165, brew_time: 2) }
+
+  it "creates new customer subscription" do
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [tea.id, tea_2.id],
+      "title": "Tea for Two",
+      "price": 15,
+      "frequency": "weekly"
+    }
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 201
+
+    subscription = JSON.parse(response.body, headers: true)[:data]
+    teas = JSON.parse(response.body, headers: true)[:data][:relationships][:teas][:data]
+    expect(subscription[:type]).to eq "subscription"
+    expect(teas).to be_an Array
+    expect(teas).to all(include (:id, type: "tea"))
+
+    attributes = subscription[:attributes]
+    expect(attributes[:title]).to eq "Tea for Two"
+    expect(attributes[:price]).to eq 15
+    expect(attributes[:frequency]).to eq "weekly"
+    expect(attributes[:status]).to eq "active"
+  end
+
+  xit "requires valid customer id" do
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [tea.id, tea_2.id],
+      "title": "Tea for Two",
+      "price": 15,
+      "frequency": "weekly"
+    }
+
+    post "/api/v0/customers/0/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 404
+  end
+
+  xit "requires valid tea id's" do
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [0],
+      "title": "Tea for Two",
+      "price": 15,
+      "frequency": "weekly"
+    }
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 404
+  end
+
+  xit "customer can't have duplicate subscription" do
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [tea.id, tea_2.id],
+      "title": "Tea for Two",
+      "price": 15,
+      "frequency": "weekly"
+    }
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 201
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 422
+  end
+
+  xit "requires valid subscription data"
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [tea.id, tea_2.id],
+      "title": "",
+      "price": "",
+      "frequency": ""
+    }
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 400
+  end
+
+  xit "requires at least 1 tea to be given" do
+    headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    body = {
+      "teas": [],
+      "title": "Tea for Two",
+      "price": 15,
+      "frequency": "weekly"
+    }
+
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
+    expect(response.status).to eq 400
+  end
+end

--- a/spec/requests/api/v0/customer_adds_subscription_spec.rb
+++ b/spec/requests/api/v0/customer_adds_subscription_spec.rb
@@ -8,24 +8,26 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
   it "creates new customer subscription" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
-      "teas": [tea.id, tea_2.id],
+      "teas": [tea_1.id, tea_2.id],
       "title": "Tea for Two",
       "price": 15,
-      "frequency": "weekly"
+      "frequency": "weekly",
+      "status": "active"
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
     expect(response.status).to eq 201
-
-    subscription = JSON.parse(response.body, headers: true)[:data]
-    teas = JSON.parse(response.body, headers: true)[:data][:relationships][:teas][:data]
+    
+    subscription = JSON.parse(response.body, symbolize_names: true)[:data]
+    teas = JSON.parse(response.body, symbolize_names: true)[:data][:relationships][:teas][:data]
     expect(subscription[:type]).to eq "subscription"
     expect(teas).to be_an Array
-    expect(teas).to all(include (:id, type: "tea"))
+    expect(teas.size).to eq 2
+    expect(teas).to all(include("type": "tea"))
 
     attributes = subscription[:attributes]
     expect(attributes[:title]).to eq "Tea for Two"
-    expect(attributes[:price]).to eq 15
+    expect(attributes[:price]).to eq 15.0
     expect(attributes[:frequency]).to eq "weekly"
     expect(attributes[:status]).to eq "active"
   end
@@ -33,10 +35,11 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
   xit "requires valid customer id" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
-      "teas": [tea.id, tea_2.id],
+      "teas": [tea_1.id, tea_2.id],
       "title": "Tea for Two",
       "price": 15,
-      "frequency": "weekly"
+      "frequency": "weekly",
+      "status": "active"
     }
 
     post "/api/v0/customers/0/subscriptions", params: body, headers: headers
@@ -49,7 +52,8 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
       "teas": [0],
       "title": "Tea for Two",
       "price": 15,
-      "frequency": "weekly"
+      "frequency": "weekly",
+      "status": "active"
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
@@ -59,10 +63,11 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
   xit "customer can't have duplicate subscription" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
-      "teas": [tea.id, tea_2.id],
+      "teas": [tea_1.id, tea_2.id],
       "title": "Tea for Two",
       "price": 15,
-      "frequency": "weekly"
+      "frequency": "weekly",
+      "status": "active"
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
@@ -72,13 +77,14 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     expect(response.status).to eq 422
   end
 
-  xit "requires valid subscription data"
+  xit "requires valid subscription data" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
-      "teas": [tea.id, tea_2.id],
+      "teas": [tea_1.id, tea_2.id],
       "title": "",
       "price": "",
-      "frequency": ""
+      "frequency": "",
+      "status": ""
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
@@ -91,7 +97,8 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
       "teas": [],
       "title": "Tea for Two",
       "price": 15,
-      "frequency": "weekly"
+      "frequency": "weekly",
+      "status": "active"
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers

--- a/spec/requests/api/v0/customer_adds_subscription_spec.rb
+++ b/spec/requests/api/v0/customer_adds_subscription_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     expect(attributes[:status]).to eq "active"
   end
 
-  xit "requires valid customer id" do
+  it "requires valid customer id" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
       "teas": [tea_1.id, tea_2.id],
@@ -46,7 +46,7 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     expect(response.status).to eq 404
   end
 
-  xit "requires valid tea id's" do
+  it "requires valid tea id's" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
       "teas": [0],
@@ -60,24 +60,7 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     expect(response.status).to eq 404
   end
 
-  xit "customer can't have duplicate subscription" do
-    headers = {"Content_Type": "application/json", "Accept": "application/json"}
-    body = {
-      "teas": [tea_1.id, tea_2.id],
-      "title": "Tea for Two",
-      "price": 15,
-      "frequency": "weekly",
-      "status": "active"
-    }
-
-    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
-    expect(response.status).to eq 201
-
-    post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
-    expect(response.status).to eq 422
-  end
-
-  xit "requires valid subscription data" do
+  it "requires valid subscription data" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
       "teas": [tea_1.id, tea_2.id],
@@ -91,7 +74,7 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     expect(response.status).to eq 400
   end
 
-  xit "requires at least 1 tea to be given" do
+  it "requires at least 1 tea to be given" do
     headers = {"Content_Type": "application/json", "Accept": "application/json"}
     body = {
       "teas": [],
@@ -102,6 +85,6 @@ RSpec.describe "POST /api/v0/customers/:customer_id/subscriptions" do
     }
 
     post "/api/v0/customers/#{customer.id}/subscriptions", params: body, headers: headers
-    expect(response.status).to eq 400
+    expect(response.status).to eq 404
   end
 end


### PR DESCRIPTION
**Summary**
Creates endpoint for a customer to add a tea subscription.
Seed data for 1 customer and 2 teas added.

<details>
<summary>Endpoint Example</summary>

Request
```http
POST http://localhost:3000/api/v0/customers/1/subscriptions
```

Body
```JSON
{
  "teas": [1, 2],
  "title": "Tea for Two",
  "price": 15,
  "frequency": "weekly",
  "status": "active"
}
```

Response
```JSON
{
  "data": {
    "id": "1",
    "type": "subscription",
    "attributes": {
      "title": "Tea for Two",
      "price": 15.0,
      "status": "active",
      "frequency": "weekly"
    },
    "relationships": {
      "teas": {
        "data": [
          {
            "id": "1",
            "type": "tea"
          },
          {
            "id": "2",
            "type": "tea"
          }
        ]
      }
    }
  }
}
```
</details>

**Testing**
Happy and sad paths tested. Full test coverage per simplecov gem.

**Issues**
Closes #2 