### PR TITLE
get all a customer's subscriptions

### DIFF
--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -15,6 +15,12 @@ class Api::V0::SubscriptionsController < ApplicationController
     render json: SubscriptionSerializer.new(subscription), status: :ok
   end
 
+  def index
+    customer = Customer.find(params[:customer_id])
+    subscriptions = customer.subscriptions
+    render json: SubscriptionSerializer.new(subscriptions)
+  end
+
   private
   def subscription_params
     params.permit(:title, :price, :frequency, :status, :customer_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :customers, only: [] do
-        resources :subscriptions, only: [:create, :update]
+        resources :subscriptions, only: [:create, :update, :index]
       end
     end
   end

--- a/spec/requests/api/v0/customer_cancels_subscription_spec.rb
+++ b/spec/requests/api/v0/customer_cancels_subscription_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "PATCH /api/v0/customers/:customer_id/subscriptions" do
+RSpec.describe "PATCH /api/v0/customers/:customer_id/subscriptions/:id" do
   let!(:customer) { Customer.create(first_name: "John", last_name: "Doe", email: "email@email.com", address: "123 4th Ave, Indianapolis, IN, 46259") }
   let!(:tea_1) { Tea.create(title: "Earl Grey", description: "great in the morning", temperature: 195, brew_time: 3.5) }
   let!(:tea_2) { Tea.create(title: "Green Tea", description: "soothing", temperature: 165, brew_time: 2) }
@@ -11,7 +11,7 @@ RSpec.describe "PATCH /api/v0/customers/:customer_id/subscriptions" do
     post "/api/v0/customers/#{customer.id}/subscriptions", params: @add_subscription_body, headers: @headers
   end
 
-  it "creates new customer subscription" do
+  it "cancels customer subscription" do
     cancel_subscription_body = { "status": "cancelled" }
     patch "/api/v0/customers/#{customer.id}/subscriptions/#{Subscription.last.id}", params: cancel_subscription_body, headers: @headers
     expect(response.status).to eq 200

--- a/spec/requests/api/v0/list_one_customers_subscriptions_spec.rb
+++ b/spec/requests/api/v0/list_one_customers_subscriptions_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "GET /api/v0/customers/:customer_id/subscriptions" do
+  let!(:customer) { Customer.create(first_name: "John", last_name: "Doe", email: "email@email.com", address: "123 4th Ave, Indianapolis, IN, 46259") }
+  let!(:tea_1) { Tea.create(title: "Earl Grey", description: "great in the morning", temperature: 195, brew_time: 3.5) }
+  let!(:tea_2) { Tea.create(title: "Green Tea", description: "soothing", temperature: 165, brew_time: 2) }
+  let!(:tea_3) { Tea.create(title: "Chai Tea", description: "yes", temperature: 175, brew_time: 4) }
+
+  before do
+    @headers = {"Content_Type": "application/json", "Accept": "application/json"}
+    @add_subscription_1 = { "teas": [tea_1.id, tea_2.id], "title": "Tea for Two", "price": 15, "frequency": "weekly", "status": "active" }
+    @add_subscription_2 = { "teas": [tea_3.id], "title": "Par-tea!", "price": 10, "frequency": "monthly", "status": "active" }
+    @cancel_subscription_2 = { "status": "cancelled" }
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: @add_subscription_1, headers: @headers
+    post "/api/v0/customers/#{customer.id}/subscriptions", params: @add_subscription_2, headers: @headers
+    patch "/api/v0/customers/#{customer.id}/subscriptions/#{Subscription.last.id}", params: @cancel_subscription_2, headers: @headers
+  end
+
+  it "lists all customer's subscriptions" do
+    get "/api/v0/customers/#{customer.id}/subscriptions", headers: @headers
+    expect(response.status).to eq 200
+
+    subscriptions = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(subscriptions).to be_an Array
+    expect(subscriptions.size).to eq 2
+    expect(subscriptions).to all(include("type": "subscription"))
+    expect(subscriptions[0][:attributes][:status]).to eq "active"
+    expect(subscriptions[1][:attributes][:status]).to eq "cancelled"
+  end
+
+  it "requires valid customer id" do
+    cancel_subscription_body = { "status": "cancelled" }
+    patch "/api/v0/customers/0/subscriptions/#{Subscription.last.id}", params: cancel_subscription_body, headers: @headers
+    expect(response.status).to eq 404
+  end
+end


### PR DESCRIPTION
**Summary**
Creates endpoint for to list all of a customer's tea subscriptions. Includes active and cancelled subscriptions.

<details>
<summary>Endpoint Example</summary>

Request
```http
GET /api/v0/customers/1/subscriptions
```

Response
```JSON
{
  "data": [
    {
      "id": "1",
      "type": "subscription",
      "attributes": {
        "title": "Tea for Two",
        "price": 15.0,
        "status": "active",
        "frequency": "weekly"
      },
      "relationships": {
        "teas": {
          "data": [
            {
              "id": "1",
              "type": "tea"
            },
            {
              "id": "2",
              "type": "tea"
            }
          ]
        }
      }
    },
    {
      "id": "2",
      "type": "subscription",
      "attributes": {
        "title": "Par-tea!",
        "price": 10.0,
        "status": "cancelled",
        "frequency": "monthly"
      },
      "relationships": {
        "teas": {
          "data": [
            {
              "id": "3",
              "type": "tea"
            }
          ]
        }
      }
    }
  ]
}
```
</details>

**Testing**
All tests passing. Full coverage per simplecov gem.

**Issues**
closes #3 
